### PR TITLE
sent rate limit info in response

### DIFF
--- a/src/error-components/rate-limit/components/rate-limit/rate-limit.tsx
+++ b/src/error-components/rate-limit/components/rate-limit/rate-limit.tsx
@@ -6,6 +6,7 @@ import { useGracefulTheme } from '../../../../hooks'
 import { Paper, Typography, TypographyProps } from '@mui/material'
 import { DefaultText } from '../../../types'
 import { useMostRecentError } from '../../../decider'
+import { getResetTime } from '../../../../scenarios'
 
 type RateLimitInitialText =
   | 'sorry'
@@ -65,12 +66,7 @@ export const RateLimitInitial: FC<RateLimitInitialProps> = ({
     ctx: { headers, responseBody },
   } = useMostRecentError()
 
-  const deltaSeconds =
-    responseBody?.rateLimitReset ?? headers?.['x-ratelimit-reset'] ?? 0
-
-  const resetTime = new Date()
-
-  resetTime.setSeconds(resetTime.getSeconds() + deltaSeconds)
+  const { resetTime, deltaSeconds } = getResetTime(responseBody, headers)
 
   return (
     <>

--- a/src/scenarios/decider.ts
+++ b/src/scenarios/decider.ts
@@ -1,3 +1,5 @@
+import { getResetTime } from './utils'
+
 export const checkHeaderAndBody = (
   data: any,
   headers: Record<Lowercase<string>, string>
@@ -19,6 +21,8 @@ export const checkHeaderAndBody = (
   return {
     retryAfter,
     retryLimit,
+    rateLimitRemaining,
+    resetAfter: getResetTime(data, headers),
     check: !rateLimitRemaining ? false : !!retryAfter,
   }
 }

--- a/src/scenarios/utils.ts
+++ b/src/scenarios/utils.ts
@@ -63,3 +63,17 @@ export const createGracefulPropsWithAxios: CreateGracefulPropsWithAxios = (
     method: res.config.method || '',
   }
 }
+
+export const getResetTime = (
+  responseBody: any,
+  headers: Record<string, string>
+) => {
+  const deltaSeconds =
+    responseBody?.rateLimitReset ?? headers?.['x-ratelimit-reset'] ?? 0
+
+  const resetTime = new Date()
+
+  resetTime.setSeconds(resetTime.getSeconds() + deltaSeconds)
+
+  return { resetTime, deltaSeconds }
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Bug fix: The code now properly calculates and sends rate limit information in the response. Refactor: The code has been modified to use a new function called `getResetTime` to calculate the reset time for rate limits, and a new type `RateLimitInfo` has been added to the `graceful-request` module. 

> "Code changes abound,
> Rate limits now correctly found.
> With `getResetTime` at hand,
> The code's functionality is grand."
<!-- end of auto-generated comment: release notes by openai -->