### PR TITLE
allow user exponential backoff func

### DIFF
--- a/src/graceful-request/graceful-request.ts
+++ b/src/graceful-request/graceful-request.ts
@@ -66,7 +66,6 @@ export const getGracefulProps = async (params: GetGracefulPropsParams) => {
 export declare type GracefulRequestOptions = {
   enableRetry: boolean
   exponentialBackOffFn: ExponentialBackOffFn
-  maxBackOffTime: number
 }
 
 export const defaultGracefulRequestOptions = {

--- a/src/scenarios/decider.ts
+++ b/src/scenarios/decider.ts
@@ -77,7 +77,7 @@ export const exponentialBackOff = (
     }
   }
 
-  if (isFunction(backOffFunc)) {
+  if (isFunction(backOffFunc) && !userExponentialBackOffFn) {
     return backOffFunc(status, numberOfRetries)
   }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Removed the `maxBackOffTime` property from the `GracefulRequestOptions` interface in `src/graceful-request/graceful-request.ts`. This change simplifies the configuration options.
- New Feature: Updated the `exponentialBackOff` function in `src/scenarios/decider.ts` to allow for a custom exponential backoff function. Users can now provide their own backoff function, which will be used if the `userExponentialBackOffFn` flag is not set. This provides more flexibility in handling request retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->